### PR TITLE
Github enterprise optional mirror source, latest ruby_rbenv cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,10 @@ default['minimart']['url'] = 'http://localhost'
 # TODO: need to setup ssh correctly
 default['minimart']['repositories']['github_parse'] = 'https'
 default['minimart']['repositories']['github'] = {}
+default['minimart']['repositories']['github_ent_parse'] = 'https'
+default['minimart']['repositories']['github_ent_host'] = nil
+default['minimart']['repositories']['github_ent'] = {}
+default['minimart']['repositories']['mirror_dependencies'] = false
 # If True, you should manually generate your inventory file in some way
 default['minimart']['use_custom_inventory'] = false
 ################################################################################

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email 'wzooff@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures minimart supermarket'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.4'
+version          '0.5.0'
 source_url       'https://github.com/wzooff/minimart-cookbook'
 issues_url       'https://github.com/wzooff/minimart-cookbook/issues'
 chef_version     '>= 12.1'
 
-depends 'ruby_rbenv', '~> 1.1.0'
+depends 'ruby_rbenv'
 depends 'ruby_build'
 
 gem 'git'

--- a/recipes/_minimart.rb
+++ b/recipes/_minimart.rb
@@ -1,9 +1,21 @@
-include_recipe 'ruby_rbenv::system_install'
+rbenv_system_install 'install rbenv globally'
 include_recipe 'ruby_build'
 rbenv_ruby node['minimart']['ruby_version']
 rbenv_global node['minimart']['ruby_version']
-rbenv_gem 'minimart'
-rbenv_gem 'execjs'
+
+%w(
+  gcc-c++
+).each do |pkg|
+  package pkg
+end
+
+rbenv_gem 'minimart' do
+  rbenv_version node['minimart']['ruby_version']
+end
+
+rbenv_gem 'execjs' do
+  rbenv_version node['minimart']['ruby_version']
+end
 
 directory node['minimart']['path'] do
   mode 00755

--- a/recipes/_repository.rb
+++ b/recipes/_repository.rb
@@ -3,33 +3,52 @@ ruby_block 'get_repo_list' do
     require 'nokogiri'
     require 'git'
 
-    def github_web_list
+    def github_web_list(github_host, repositories)
       cookbook_repositories = []
-      node['minimart']['repositories']['github'].each do |name, repo|
-        tag_url = "https://github.com/#{repo}/tags"
+      repositories.each do |name, repo|
+        tag_url = "https://#{github_host}/#{repo}/tags"
         repo_tags = []
         Nokogiri::HTML(Chef::HTTP.new(tag_url).get('/', {})).css('span.tag-name').each do |tag|
           repo_tags << tag.text
         end
-        cookbook_repositories << [name.to_s, "https://github.com/#{repo}.git", repo_tags]
+        unless repo_tags == []
+          cookbook_repositories << [name.to_s, "https://#{github_host}/#{repo}.git", repo_tags]
+        else
+          cookbook_repositories << [name.to_s, "https://#{github_host}/#{repo}.git", 'master']
+        end
       end
       cookbook_repositories
     end
 
     def github_git_list
       cookbook_repositories = []
-      node['minimart']['repositories']['github'].each do |name, repo|
-        repo_tags = Git.ls_remote("ssh://git@github.com/#{repo}.git")['tags'].keys.select { |tag| tag =~ /\d$/ }
-        cookbook_repositories << [name.to_s, "git@github.com:#{repo}.git", repo_tags] if repo_tags != []
+      repositories.each do |name, repo|
+        repo_tags = Git.ls_remote("ssh://git@#{github_host}/#{repo}.git")['tags'].keys.select { |tag| tag =~ /\d$/ }
+        unless repo_tags == []
+          cookbook_repositories << [name.to_s, "git@#{github_host}:#{repo}.git", repo_tags]
+        else
+          cookbook_repositories << [name.to_s, "git@#{github_host}:#{repo}.git", 'master']
+        end
       end
       cookbook_repositories
     end
 
     cblist = if node['minimart']['repositories']['github_parse'] == 'https'
-               github_web_list
+               github_web_list('github.com', node['minimart']['repositories']['github'])
              else
-               github_git_list
+               github_git_list('github.com', node['minimart']['repositories']['github'])
              end
+
+    unless node['minimart']['repositories']['github_ent_host'].nil?
+      ent_cblist = if node['minimart']['repositories']['github_ent_parse'] == 'https'
+                 github_web_list(node['minimart']['repositories']['github_ent_host'], node['minimart']['repositories']['github_ent'])
+               else
+                 github_git_list(node['minimart']['repositories']['github_ent_host'], node['minimart']['repositories']['github_ent'])
+               end
+    end
+
+    cblist.push(*ent_cblist)
+
     # oh my... dirty hack to pass array without attributes )
     r = Chef::Resource::Template.new("#{node['minimart']['path']}/inventory.yml.erb", run_context)
     r.path       "#{node['minimart']['path']}/inventory.yml.erb"
@@ -53,15 +72,21 @@ template "#{node['minimart']['path']}/inventory.yml" do
   not_if { node['minimart']['custom_inventory'] }
 end
 
-bash 'mirror' do
-  code 'minimart mirror'
+rbenv_script 'mirror' do
+  rbenv_version node['minimart']['ruby_version']
+  if node['minimart']['repositories']['mirror_dependencies']
+    code 'minimart mirror --load-deps'
+  else
+    code 'minimart mirror'
+  end
   cwd node['minimart']['path']
   action :nothing
   subscribes :run, "template[#{node['minimart']['path']}/inventory.yml]", :immediately
-  notifies :run, 'bash[web]', :immediately
+  notifies :run, 'rbenv_script[web]', :immediately
 end
 
-bash 'web' do
+rbenv_script 'web' do
+  rbenv_version node['minimart']['ruby_version']
   code "minimart web --host #{node['minimart']['url']}"
   cwd node['minimart']['path']
   action :nothing

--- a/recipes/_web.rb
+++ b/recipes/_web.rb
@@ -5,10 +5,6 @@ package 'nginx' do
   action :install
 end
 
-service 'nginx' do
-  subscribes :restart, 'bash[web]', :delayed
-end
-
 file '/etc/nginx/nginx.conf' do
   content <<-EOF.gsub(/^ {4}/, '')
     user nginx;
@@ -51,4 +47,9 @@ file '/etc/nginx/nginx.conf' do
     }
   EOF
   notifies :reload, 'service[nginx]', :delayed
+end
+
+service 'nginx' do
+  subscribes :restart, 'rbenv_script[web]', :delayed
+  action [:start, :enable]
 end

--- a/templates/default/inventory.yml.erb
+++ b/templates/default/inventory.yml.erb
@@ -3,8 +3,12 @@ cookbooks:
   <%= item %>:
     git:
       location: '<%= location %>'
+      <% if tags == 'master' %>
+      branch: "<%= tags %>"
+      <% else %>
       tags:
-      <% tags.each do |tag| %>
+        <% tags.each do |tag| %>
         - <%= tag %>
+        <% end %>
       <% end %>
 <% end %>


### PR DESCRIPTION
## Adds

* Additional Github Enterprise source - Optional
* If no tags on git or github enterprise repos then mirror the master branch.
* Optionally mirror dependencies: default: false

## Changes

* Start and Enable `nginx` service if installing the web server.

## Updates

* Supports latest 'ruby_rbenv' cookbook